### PR TITLE
Add sync --from-remote and --to-remote CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ Run: `serverless meta sync`.
 ### Options
 * `-s` `--stage` — Stage. Optional if only one stage is defined in project. This will only sync the variables file of the specified stage (e.g., `s-variables-dev.json`).
 * `-r` `--region` — Region. Optional. This will only sync the variables file for the specified region in the specified stage (e.g., `s-variables-dev-useast1.json`).
+* `-f` `--from-remote` — Optional. Explicitly sync remote variables to local.
+* `-t` `--to-remote` — Optional. Explicitly sync local variables to remote.

--- a/lib/MetaSync.js
+++ b/lib/MetaSync.js
@@ -42,6 +42,14 @@ module.exports = function(S) {
             option:      'region',
             shortcut:    'r',
             description: 'Optional - Region'
+          }, {
+            option:      'from-remote',
+            shortcut:    'f',
+            description: 'Optional - Sync from remote'
+          }, {
+            option:      'to-remote',
+            shortcut:    't',
+            description: 'Optional - Sync to remote'
           },
         ],
         parameters: []
@@ -136,6 +144,9 @@ module.exports = function(S) {
     }
 
     _sync() {
+      const fromRemote = this.evt.options['from-remote'] || false;
+      const toRemote = this.evt.options['to-remote'] || false;
+
       if (!this.remoteVersion && !this.localVersion) {
         SCli.log(`${this.syncFileName} dosn't exist locally nor on S3`);
         return;
@@ -151,11 +162,26 @@ module.exports = function(S) {
         return this._updateRemote();
       }
 
+      if (fromRemote && !toRemote) {
+        SCli.log(`Downloading from remote...`);
+        return this._updateLocal();
+      }
+
+      if (toRemote && !fromRemote) {
+        SCli.log(`Uploading to remote...`);
+        return this._updateRemote();
+      }
+
+      if (fromRemote && toRemote) {
+        return BbPromise.reject(new SError(`Either specify --from-remote or --to-remote not both!`))
+      }
+
       if (S.config.interactive) {
         return this._diff();
       } else {
-        // When used programmatically, it should simply overwrite
-        // the local project variables with the variables on the S3 Bucket
+        // When used programmatically and no sync options are provided, it
+        // should simply overwrite the local project variables with the
+        // variables on the S3 Bucket
         return this._updateLocal();
       }
     }


### PR DESCRIPTION
Useful when your CI/CD deploys CloudFormation resources and you want to store the variables afterwards.
